### PR TITLE
I updated package json, it seems that with the latest versions of npm the

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">=v0.4.0"
+    "node": ">=0.4.0"
   },
   "dependencies": {},
   "devDependencies": {
-      "express": "~v2.0.0"
-    , "expresso": "v0.7.5"
+      "express": ">=2.0.0"
+    , "expresso": "0.7.5"
   }
 }


### PR DESCRIPTION
I updated package json, it seems that with the latest versions of npm the v is not very much loved, especially when run on travis-ci.org. Here is a sample output, which fails at gleak first: http://travis-ci.org/#!/scottyapp/mongoose-from-json-schema/builds/235540
Please note that I am new to this, so take this pull request with the necessary caution.
